### PR TITLE
Creating link back to GitHub repo

### DIFF
--- a/src/components/MoreMenu.jsx
+++ b/src/components/MoreMenu.jsx
@@ -3,6 +3,7 @@ import config from '../helpers/config.js';
 import IconButton from 'material-ui/IconButton';
 import IconMenu from 'material-ui/IconMenu';
 import MenuItem from 'material-ui/MenuItem';
+import Divider from 'material-ui/Divider';
 
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 
@@ -18,6 +19,12 @@ export default function MoreMenu(props) {
 			anchorOrigin={{ horizontal: 'right', vertical: 'top' }}
 		>
 			<MenuItem primaryText={config.APPLICATION_VERSION} disabled={true} />
+			<Divider />
+			<MenuItem
+				primaryText="GitHub"
+				href="https://github.com/wsfuller/react-weather"
+				target="_blank"
+			/>
 		</IconMenu>
 	);
 }


### PR DESCRIPTION
Created link back to GitHub Repo in the MoreMenu component within the AppBar

<img width="959" alt="screen shot 2017-09-24 at 1 54 20 pm" src="https://user-images.githubusercontent.com/3144419/30786807-71dfc9f2-a130-11e7-8f83-4f326dcbbd1c.png">
